### PR TITLE
Bugfix: Add io.stop after timer is cancelled

### DIFF
--- a/appl/include/diagnostic_client_conversion.h
+++ b/appl/include/diagnostic_client_conversion.h
@@ -10,6 +10,7 @@
 #define _DIAGNOSTIC_CLIENT_CONVERSION_H_
 
 #include "diagnostic_client_uds_message.h"
+#include <cstdint>
 
 namespace diag {
 namespace client {

--- a/lib/libOsAbstraction/libBoost/libTimer/oneShotSync/oneShotSyncTimer.cpp
+++ b/lib/libOsAbstraction/libBoost/libTimer/oneShotSync/oneShotSyncTimer.cpp
@@ -79,6 +79,9 @@ bool oneShotSyncTimer::IsActive() {
 // function called when time elapses
 void oneShotSyncTimer::Timeout(const boost::system::error_code& error) {
     error_e = error;
+    if(error_e == boost::asio::error::operation_aborted) {
+        io_e.stop();
+    }
 }
 
 } // oneShot


### PR DESCRIPTION
The io context run() caused crash when i sent a uds message 